### PR TITLE
Add option for recursively resolving workspaces

### DIFF
--- a/src/package-utils.ts
+++ b/src/package-utils.ts
@@ -263,14 +263,63 @@ function getManifestErrorMessagePrefix(
  *
  * @param workspaces - The list of workspace patterns given in the root manifest.
  * @param rootDir - The monorepo root directory.
+ * @param recursive - Whether to search recursively.
  * @returns The location of each workspace directory relative to the root directory
  */
 export async function getWorkspaceLocations(
   workspaces: string[],
   rootDir: string,
+  recursive = false,
+  prefix = '',
 ): Promise<string[]> {
-  const resolvedWorkspaces = await Promise.all(
-    workspaces.map((pattern) => glob(pattern, { cwd: rootDir })),
+  const resolvedWorkspaces = await workspaces.reduce<Promise<string[]>>(
+    async (promise, pattern) => {
+      const array = await promise;
+      const matches = (await glob(pattern, { cwd: rootDir })).map((match) =>
+        pathUtils.join(prefix, match),
+      );
+
+      return [...array, ...matches];
+    },
+    Promise.resolve([]),
   );
-  return resolvedWorkspaces.flat();
+
+  if (recursive) {
+    // This reads all the package JSON files in each workspace, checks if they are a monorepo, and
+    // recursively calls `getWorkspaceLocations` if they are.
+    const resolvedSubWorkspaces = await resolvedWorkspaces.reduce<
+      Promise<string[]>
+    >(async (promise, workspacePath) => {
+      const array = await promise;
+
+      const rawManifest = await getPackageManifest(workspacePath);
+      if (ManifestFieldNames.Workspaces in rawManifest) {
+        const manifest = validatePackageManifestVersion(
+          rawManifest,
+          workspacePath,
+        );
+
+        const monorepoManifest = validateMonorepoPackageManifest(
+          manifest,
+          workspacePath,
+        );
+
+        return [
+          ...array,
+          ...(await getWorkspaceLocations(
+            monorepoManifest[ManifestFieldNames.Workspaces],
+            workspacePath,
+            recursive,
+            workspacePath,
+          )),
+        ];
+      }
+
+      return array;
+    }, Promise.resolve(resolvedWorkspaces));
+
+    return resolvedSubWorkspaces;
+  }
+
+  return resolvedWorkspaces;
 }


### PR DESCRIPTION
This PR is similar to MetaMask/action-create-release-pr#85, but as @mcmire brought up, only patching this in `action-create-release-pr` creates differences between that package and other packages, such as `action-publish-release`.

This adds a third parameter to the `getWorkspaceLocations` function, which specifies whether you want to do a recursive search. When this is enabled, it:

1. Loads the `package.json` for each package.
2. Checks if the package is a monorepo (i.e., whether it contains a `workspaces` field).
3. Recursively calls `getWorkspaceLocations` for monorepo packages.

Since this is a potentially breaking change (validating `package.json` files in packages), the functionality is disabled by default.