### PR TITLE
Add recognition of engines field in package manifest

### DIFF
--- a/src/package-utils.ts
+++ b/src/package-utils.ts
@@ -36,7 +36,7 @@ export interface PackageManifest
   extends Partial<
     Record<ManifestDependencyFieldNames, Record<string, string>>
   > {
-  readonly [ManifestFieldNames.Engines]?: { [k in EngineNames]?: string };
+  readonly [ManifestFieldNames.Engines]?: { [name in EngineNames]?: string };
   readonly [ManifestFieldNames.Name]: string;
   readonly [ManifestFieldNames.Private]?: boolean;
   readonly [ManifestFieldNames.Version]: string;
@@ -47,13 +47,13 @@ export interface PolyrepoPackageManifest
   extends Partial<
     Record<ManifestDependencyFieldNames, Record<string, string>>
   > {
-  readonly [ManifestFieldNames.Engines]?: { [k in EngineNames]?: string };
+  readonly [ManifestFieldNames.Engines]?: { [name in EngineNames]?: string };
   readonly [ManifestFieldNames.Name]: string;
   readonly [ManifestFieldNames.Version]: string;
 }
 
 export interface MonorepoPackageManifest extends Partial<PackageManifest> {
-  readonly [ManifestFieldNames.Engines]?: { [k in EngineNames]?: string };
+  readonly [ManifestFieldNames.Engines]?: { [name in EngineNames]?: string };
   readonly [ManifestFieldNames.Private]: boolean;
   readonly [ManifestFieldNames.Version]: string;
   readonly [ManifestFieldNames.Workspaces]: string[];

--- a/src/package-utils.ts
+++ b/src/package-utils.ts
@@ -18,16 +18,25 @@ export enum ManifestDependencyFieldNames {
 }
 
 export enum ManifestFieldNames {
+  Engines = 'engines',
   Name = 'name',
   Private = 'private',
   Version = 'version',
   Workspaces = 'workspaces',
 }
 
+export enum EngineNames {
+  Node = 'node',
+  Npm = 'npm',
+  Pnpm = 'pnpm',
+  Yarn = 'yarn',
+}
+
 export interface PackageManifest
   extends Partial<
     Record<ManifestDependencyFieldNames, Record<string, string>>
   > {
+  readonly [ManifestFieldNames.Engines]?: { [k in EngineNames]?: string };
   readonly [ManifestFieldNames.Name]: string;
   readonly [ManifestFieldNames.Private]?: boolean;
   readonly [ManifestFieldNames.Version]: string;
@@ -38,13 +47,15 @@ export interface PolyrepoPackageManifest
   extends Partial<
     Record<ManifestDependencyFieldNames, Record<string, string>>
   > {
+  readonly [ManifestFieldNames.Engines]?: { [k in EngineNames]?: string };
   readonly [ManifestFieldNames.Name]: string;
   readonly [ManifestFieldNames.Version]: string;
 }
 
 export interface MonorepoPackageManifest extends Partial<PackageManifest> {
-  readonly [ManifestFieldNames.Version]: string;
+  readonly [ManifestFieldNames.Engines]?: { [k in EngineNames]?: string };
   readonly [ManifestFieldNames.Private]: boolean;
+  readonly [ManifestFieldNames.Version]: string;
   readonly [ManifestFieldNames.Workspaces]: string[];
 }
 


### PR DESCRIPTION
This adds recognition of the [`engines`](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#engines) field in package manifests.

While field keys can be arbitrary package/engine names, this currently restricts it to `node` and known package managers (`npm`/`pnpm`/`yarn`).