### PR TITLE
chore: declare yarn version 1.22.22 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^16.20 || ^18.16 || >=20"
+    "node": "^16.20 || ^18.16 || >=20",
+    "yarn": "^1.22.22"
   },
   "files": [
     "dist/"
@@ -62,5 +63,6 @@
     "allowScripts": {
       "@lavamoat/preinstall-always-fail": false
     }
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
Pin current (latest) yarn v1.x version in order to make `corepack enable` pick up the correct version when working with this repo.

### Related
- https://github.com/MetaMask/metamask-mobile/pull/9143
- https://github.com/MetaMask/action-create-release-pr/pull/135